### PR TITLE
Rationalise pkgs and add qrexec lib and dom0 tools

### DIFF
--- a/findtag.sh
+++ b/findtag.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-#
-# Usage:
-#
-# findtag.sh <linuxkit build dir>
-#
-linuxkit pkg show-tag $1
-

--- a/makeraw.sh
+++ b/makeraw.sh
@@ -5,4 +5,4 @@
 #
 MKIMAGE_TAG="$(linuxkit pkg show-tag pkg/mkimage-raw-efi)-amd64"
 
-moby build -o - $1 | docker run -v /dev:/dev --privileged -i ${MKIMAGE_TAG} > $2
+linuxkit build -o - $1 | docker run -v /dev:/dev --privileged -i ${MKIMAGE_TAG} > $2

--- a/parse-pkgs.sh
+++ b/parse-pkgs.sh
@@ -4,6 +4,11 @@
 #
 # [1] A poor man is a man on a deadline.
 #
+
+linuxkit_tag() {
+    linuxkit pkg show-tag $1
+}
+
 plugin_tag() {
   if (docker inspect "$1" || docker pull "$1") > /dev/null 2>&1 ; then
     echo $1
@@ -15,14 +20,14 @@ plugin_tag() {
 
 ARCH=amd64
 
-KERNEL_TAG=$(./findtag.sh pkg/kernel)-$ARCH
-XENTOOLS_TAG=$(./findtag.sh pkg/xen-tools)-$ARCH
-XEN_TAG=$(./findtag.sh pkg/xen)-$ARCH
-DNSMASQ_TAG=$(./findtag.sh pkg/dnsmasq)-$ARCH
-TESTCERT_TAG=$(./findtag.sh pkg/test-cert)-$ARCH
-TESTMSVCS_TAG=$(./findtag.sh pkg/test-microsvcs)-$ARCH
-ZEDEDA_TAG=$(./findtag.sh zededa-container)-$ARCH
-DOM0ZTOOLS_TAG=$(./findtag.sh pkg/dom0-ztools)-$ARCH
+KERNEL_TAG=$(linuxkit_tag pkg/kernel)-$ARCH
+XENTOOLS_TAG=$(linuxkit_tag pkg/xen-tools)-$ARCH
+XEN_TAG=$(linuxkit_tag pkg/xen)-$ARCH
+DNSMASQ_TAG=$(linuxkit_tag pkg/dnsmasq)-$ARCH
+TESTCERT_TAG=$(linuxkit_tag pkg/test-cert)-$ARCH
+TESTMSVCS_TAG=$(linuxkit_tag pkg/test-microsvcs)-$ARCH
+ZEDEDA_TAG=$(linuxkit_tag zededa-container)-$ARCH
+DOM0ZTOOLS_TAG=$(linuxkit_tag pkg/dom0-ztools)-$ARCH
 
 # Plugin tags: the following tags will default to
 # 'scratch' Docker container if not available.
@@ -30,7 +35,7 @@ DOM0ZTOOLS_TAG=$(./findtag.sh pkg/dom0-ztools)-$ARCH
 # our build easier. WARNING: it also means if you're
 # not logged into the Docker hub you may see final
 # images lacking functionality.
-ZTOOLS_TAG=${ZTOOLS_TAG:-`plugin_tag zededa/ztools:latest`}
+ZTOOLS_TAG=${ZTOOLS_TAG:-$(plugin_tag zededa/ztools:latest)}
 
 sed -e "s#KERNEL_TAG#"$KERNEL_TAG"#" \
     -e "s#XENTOOLS_TAG#"$XENTOOLS_TAG"#" \

--- a/parse-pkgs.sh
+++ b/parse-pkgs.sh
@@ -28,6 +28,7 @@ TESTCERT_TAG=$(linuxkit_tag pkg/test-cert)-$ARCH
 TESTMSVCS_TAG=$(linuxkit_tag pkg/test-microsvcs)-$ARCH
 ZEDEDA_TAG=$(linuxkit_tag zededa-container)-$ARCH
 DOM0ZTOOLS_TAG=$(linuxkit_tag pkg/dom0-ztools)-$ARCH
+QREXECLIB_TAG=$(linuxkit_tag pkg/qrexec-lib)-$ARCH
 
 # Plugin tags: the following tags will default to
 # 'scratch' Docker container if not available.
@@ -46,4 +47,5 @@ sed -e "s#KERNEL_TAG#"$KERNEL_TAG"#" \
     -e "s#TESTMSVCS_TAG#"$TESTMSVCS_TAG"#" \
     -e "s#ZEDEDA_TAG#"$ZEDEDA_TAG"#" \
     -e "s#ZTOOLS_TAG#"$ZTOOLS_TAG"#" \
+    -e "s#QREXECLIB_TAG#"$QREXECLIB_TAG"#" \
     $1

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -2,7 +2,8 @@
 LINUXKIT_OPTS= --disable-content-trust
 
 PKGS = xen kernel xen-tools mkimage-iso-efi mkimage-raw-efi \
-	dnsmasq dom0-ztools test-cert test-microsvcs
+	dnsmasq dom0-ztools test-cert test-microsvcs \
+	qrexec-lib qrexec-dom0
 
 .PHONY: push force-push build forcebuild show-tag clean dockerfiles
 

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,22 +1,30 @@
 # disable content trust for now
 LINUXKIT_OPTS= --disable-content-trust
 
-DIRS = $(dir $(shell find . -maxdepth 2 -mindepth 2 -type f -name build.yml))
-.PHONY: push force-push build forcebuild show-tag clean
+PKGS = xen kernel xen-tools mkimage-iso-efi mkimage-raw-efi \
+	dnsmasq dom0-ztools test-cert test-microsvcs
 
-build:
-	@set -e; for d in $(DIRS); do linuxkit pkg build ${LINUXKIT_OPTS} "$$d"; done
+.PHONY: push force-push build forcebuild show-tag clean dockerfiles
+
+build: #dockerfiles
+	@set -e; for d in $(PKGS); do linuxkit pkg build ${LINUXKIT_OPTS} "$$d"; done
 
 push:
-	@set -e; for d in $(DIRS); do linuxkit pkg push ${LINUXKIT_OPTS} "$$d"; done
+	@set -e; for d in $(PKGS); do linuxkit pkg push ${LINUXKIT_OPTS} "$$d"; done
 
 forcepush:
-	@set -e; for d in $(DIRS); do linuxkit pkg push --force ${LINUXKIT_OPTS} "$$d"; done
+	@set -e; for d in $(PKGS); do linuxkit pkg push --force ${LINUXKIT_OPTS} "$$d"; done
 
 forcebuild:
-	@set -e; for d in $(DIRS); do linuxkit pkg build --force ${LINUXKIT_OPTS} "$$d"; done
+	@set -e; for d in $(PKGS); do linuxkit pkg build --force ${LINUXKIT_OPTS} "$$d"; done
 
 show-tag:
-	@set -e; for d in $(DIRS); do linuxkit pkg show-tag "$$d"; done
+	@set -e; for d in $(PKGS); do linuxkit pkg show-tag "$$d"; done
 
 clean:
+
+dockerfiles: $(addsuffix Dockerfile, $(PKGS)/)
+
+%: %.template FORCE
+	(cd ..; ./parse-pkgs.sh pkg/$< > pkg/$@)
+FORCE:

--- a/pkg/qrexec-dom0/Dockerfile.template
+++ b/pkg/qrexec-dom0/Dockerfile.template
@@ -1,0 +1,27 @@
+FROM XENTOOLS_TAG as xentools
+FROM QREXECLIB_TAG as qrexec_lib
+FROM alpine:3.6 as build
+
+RUN apk add --no-cache \
+    gcc \
+    make \
+    libc-dev \
+    linux-headers \
+    git
+
+COPY --from=xentools / /
+COPY --from=qrexec_lib / /
+
+RUN git clone https://github.com/Zededa/qubes-core-admin-linux /qubes-core-admin-linux
+
+RUN mkdir -p /out/usr/bin
+
+WORKDIR /qubes-core-admin-linux/qrexec
+
+RUN make BACKEND_VMM=xen
+RUN cp qrexec-daemon qrexec-client /out/usr/bin
+
+FROM scratch
+ENTRYPOINT []
+CMD []
+COPY --from=build /out /

--- a/pkg/qrexec-dom0/build.yml
+++ b/pkg/qrexec-dom0/build.yml
@@ -1,0 +1,3 @@
+org: zededa
+image: qrexec-dom0
+network: yes

--- a/pkg/qrexec-lib/Dockerfile.template
+++ b/pkg/qrexec-lib/Dockerfile.template
@@ -1,0 +1,43 @@
+FROM XENTOOLS_TAG as xentools
+
+FROM alpine:3.6	as build
+
+RUN apk add --no-cache \
+    gcc \
+    make \
+    libc-dev \
+    linux-headers \
+    git
+
+
+COPY --from=xentools / /
+
+RUN git clone https://github.com/QubesOS/qubes-core-vchan-xen qubes-core-vchan-xen
+RUN git clone https://github.com/Zededa/qubes-linux-utils qubes-util-linux
+
+RUN mkdir /out
+RUN mkdir -p /out/usr/lib
+RUN mkdir -p /out/usr/include
+RUN mkdir -p /out/usr/share/pkgconfig
+
+WORKDIR /qubes-core-vchan-xen/u2mfn
+RUN make
+RUN cp libu2mfn.so /out/usr/lib
+WORKDIR /qubes-core-vchan-xen/vchan
+RUN make -f Makefile.linux
+RUN cp libvchan-xen.so /usr/lib
+RUN cp vchan-xen.pc /usr/share/pkgconfig
+RUN cp libvchan.h /usr/include
+RUN cp libvchan-xen.so /out/usr/lib
+RUN cp vchan-xen.pc /out/usr/share/pkgconfig
+RUN cp libvchan.h /out/usr/include
+
+WORKDIR /qubes-util-linux/qrexec-lib
+RUN make BACKEND_VMM=xen DESTDIR=out/ INCLUDEDIR=/usr/include LIBDIR=/usr/lib
+RUN make install BACKEND_VMM=xen DESTDIR=/out/ INCLUDEDIR=/usr/include LIBDIR=/usr/lib
+
+
+FROM scratch
+ENTRYPOINT []
+CMD []
+COPY --from=build /out /

--- a/pkg/qrexec-lib/build.yml
+++ b/pkg/qrexec-lib/build.yml
@@ -1,0 +1,3 @@
+org: zededa
+image: qrexec-lib
+network: yes


### PR DESCRIPTION
This changeset clean up support for pkgs, cleaning up the tag finding script.
Also make it possible to create dependencies between packages, using tags.
Also add packages for building qrexec tools, unused in any image right now but useful for future API testing.