### PR TITLE
Add pkg/kmod_pfring

### DIFF
--- a/images/fallback.yml.in
+++ b/images/fallback.yml.in
@@ -10,6 +10,7 @@ init:
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:417f83f7b8dc1fa36acf90effe44f99c7397480a
   - linuxkit/getty:bf6872ce0a9f3ab519b3e502cc41ba3958bda2a6
+  - KMOD_PFRING_TAG
 onboot:
    - name: sysctl
      image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21

--- a/parse-pkgs.sh
+++ b/parse-pkgs.sh
@@ -21,6 +21,7 @@ plugin_tag() {
 ARCH=amd64
 
 KERNEL_TAG=$(linuxkit_tag pkg/kernel)-$ARCH
+KMOD_PFRING_TAG=$(linuxkit_tag pkg/kmod_pfring)-$ARCH
 XENTOOLS_TAG=$(linuxkit_tag pkg/xen-tools)-$ARCH
 XEN_TAG=$(linuxkit_tag pkg/xen)-$ARCH
 GRUB_TAG=$(linuxkit_tag pkg/grub)-$ARCH
@@ -56,4 +57,5 @@ sed -e "s#KERNEL_TAG#"$KERNEL_TAG"#" \
     -e "s#WLAN_TAG#"$WLAN_TAG"#" \
     -e "s#GRUB_TAG#"$GRUB_TAG"#" \
     -e "s#SGDISK_TAG#"$SGDISK_TAG"#" \
+    -e "s#KMOD_PFRING_TAG#"$KMOD_PFRING_TAG"#" \
     $1

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,9 +1,9 @@
 # disable content trust for now
 LINUXKIT_OPTS= --disable-content-trust
 
-PKGS = grub xen kernel xen-tools dnsmasq sgdisk dom0-ztools test-cert	\
-	test-microsvcs qrexec-lib qrexec-dom0 wwan wlan mkrootfs-ext4	\
-	mkflash
+PKGS = grub xen kernel kmod_pfring xen-tools dnsmasq sgdisk dom0-ztools	\
+	test-cert test-microsvcs qrexec-lib qrexec-dom0 wwan wlan	\
+	mkrootfs-ext4 mkflash
 
 .PHONY: push force-push build forcebuild show-tag clean dockerfiles
 

--- a/pkg/kmod_pfring/Dockerfile.template
+++ b/pkg/kmod_pfring/Dockerfile.template
@@ -1,0 +1,50 @@
+#
+# Stage 1: Build kernel module.
+# Output is /lib/modules (+depmod) of all base kernel drivers + this one
+#
+FROM KERNEL_TAG AS ksrc
+FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build
+RUN apk add \
+    attr-dev \
+    autoconf \
+    automake \
+    build-base \
+    file \
+    git \
+    libtirpc-dev \
+    libtool \
+    mpc1-dev \
+    mpfr-dev \
+    util-linux-dev \
+    linux-headers \
+    bison \
+    flex \
+    zlib-dev
+
+COPY --from=ksrc /kernel-dev.tar /
+RUN tar xf kernel-dev.tar
+
+# Also extract the kernel modules
+COPY --from=ksrc /kernel.tar /
+RUN tar xf kernel.tar
+
+ENV PF_BRANCH=6.6.0-stable
+ENV PF_REPO=https://github.com/ntop/PF_RING
+
+RUN git clone ${PF_REPO} && \
+    cd PF_RING && \
+    git checkout ${PF_BRANCH}
+
+WORKDIR /PF_RING/kernel
+# BUILD_KERNEL implies that only one kernel per pkg/kernel container is shipped.
+RUN for i in $(ls /lib/modules); do make all install DESTDIR=/out BUILD_KERNEL=$i; done
+
+#
+# Stage 2: Build final container
+#
+FROM scratch
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=build /out/ /
+COPY files/ /

--- a/pkg/kmod_pfring/build.yml
+++ b/pkg/kmod_pfring/build.yml
@@ -1,0 +1,3 @@
+image: kmod_pfring
+org: zededa
+network: yes

--- a/pkg/kmod_pfring/files/etc/init.d/010-kmod-pfring
+++ b/pkg/kmod_pfring/files/etc/init.d/010-kmod-pfring
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+insmod /lib/modules/$(uname -r)/kernel/net/pf_ring/pf_ring.ko
+


### PR DESCRIPTION
This creates pkg/kmod_pfring, a component that builds pf_ring, and creates a container with a module and a /etc/init.d script to insmod it at boot.

This should act as a template for building external modules in zenbuild.