### PR TITLE
Fix NICs on fallback qemu run.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,21 +6,22 @@ help:
 	@echo zenbuild: LinuxKit-based Xen images composer
 	@echo
 	@echo amd64 targets:
-	@echo "   'make supermicro.iso' builds a bootable ISO"
-	@echo "   'make supermicro.img' builds a bootable raw disk image"
 	@echo "   'make fallback.img'   builds an image with the fallback"
 	@echo "                         bootloader"
+	@echo "   'make run'            run fallback.img image using qemu'"
 	@echo
 
 pkgs:
 	make -C pkg
 
 run:
-	qemu-system-x86_64 --bios ./bios/OVMF.fd -m 4096 -cpu SandyBridge -serial mon:stdio -hda ./supermicro.img \
+	qemu-system-x86_64 --bios ./bios/OVMF.fd -m 4096 -cpu SandyBridge -serial mon:stdio -hda ./fallback.img \
 				-net nic,vlan=0 -net user,id=eth0,vlan=0,net=192.168.1.0/24,dhcpstart=192.168.1.10,hostfwd=tcp::2222-:22 \
 				-net nic,vlan=1 -net user,id=eth1,vlan=1,net=192.168.2.0/24,dhcpstart=192.168.2.10
 run-fallback:
-	qemu-system-x86_64 --bios ./bios/OVMF.fd -m 4096 -cpu SandyBridge -serial mon:stdio -hda fallback.img -redir tcp:2222::22
+	qemu-system-x86_64 --bios ./bios/OVMF.fd -m 4096 -cpu SandyBridge -serial mon:stdio -hda fallback.img \
+				-net nic,vlan=0 -net user,id=eth0,vlan=0,net=192.168.1.0/24,dhcpstart=192.168.1.10,hostfwd=tcp::2222-:22 \
+				-net nic,vlan=1 -net user,id=eth1,vlan=1,net=192.168.2.0/24,dhcpstart=192.168.2.10
 
 images/%.yml: pkgs parse-pkgs.sh images/%.yml.in FORCE
 	./parse-pkgs.sh $@.in > $@


### PR DESCRIPTION
Due to merging the feature that allowed multiple NICs on a qemu run
was lost in fallback.img.

This fixes run-fallback but also changes 'make run' into running the
fallback image, as the supermicro images are not used anymore.