### PR TITLE
Move build-tools/ Makefile goo to its own directory

### DIFF
--- a/build-tools/Makefile
+++ b/build-tools/Makefile
@@ -1,0 +1,21 @@
+PATH := $(CURDIR)/bin:$(PATH)
+COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
+COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
+BUILD_TOOLS=bin/linuxkit bin/manifest-tool
+GOC=GOPATH=$(CURDIR) go
+
+%Gopkg.lock: %Gopkg.toml
+	cd `dirname $@` ; GOPATH=$(CURDIR) $(CURDIR)/bin/dep ensure -v
+
+bin/linuxkit: src/linuxkit/Gopkg.lock
+	cd src/linuxkit/vendor/github.com/linuxkit/linuxkit/src/cmd/linuxkit ;\
+	$(GOC) build -ldflags "-X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.GitCommit=${COMMIT}" -o $(CURDIR)/$@ .
+
+bin/manifest-tool: src/manifest-tool/Gopkg.lock
+	cd src/manifest-tool/vendor/github.com/estesp/manifest-tool ;\
+	$(GOC) build -ldflags "-X main.gitCommit=${COMMIT}" -o $(CURDIR)/$@ .
+
+bin/dep:
+	$(GOC) get github.com/golang/dep/cmd/dep
+
+all: bin/dep bin/linuxkit bin/manifest-tool

--- a/build-tools/Makefile
+++ b/build-tools/Makefile
@@ -1,21 +1,24 @@
-PATH := ${CURDIR}/bin:${PATH}
-COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
-COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
-BUILD_TOOLS=bin/linuxkit bin/manifest-tool
-GOC=GOPATH=${CURDIR} go
+CURDIR != pwd
+PATH += ${CURDIR}/bin
+
+GOPATH += ${CURDIR}
+GO != which go # XXX: Provide more precise method.
+
+GIT_COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
+GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${GIT_COMMIT_NO}-dirty,${GIT_COMMIT_NO})
 
 bin/dep:
-	${GOC} get github.com/golang/dep/cmd/dep
+	${GO} get github.com/golang/dep/cmd/dep
 
 %Gopkg.lock: bin/dep %Gopkg.toml
 	cd `dirname $@` ; GOPATH=${CURDIR} ${CURDIR}/bin/dep ensure -v
 
 bin/linuxkit: src/linuxkit/Gopkg.lock
 	cd src/linuxkit/vendor/github.com/linuxkit/linuxkit/src/cmd/linuxkit ;\
-	${GOC} build -ldflags "-X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.GitCommit=${COMMIT}" -o ${CURDIR}/$@ .
+	${GO} build -ldflags "-X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.GitCommit=${GIT_COMMIT}" -o ${CURDIR}/$@ .
 
 bin/manifest-tool: src/manifest-tool/Gopkg.lock
 	cd src/manifest-tool/vendor/github.com/estesp/manifest-tool ;\
-	${GOC} build -ldflags "-X main.gitCommit=${COMMIT}" -o ${CURDIR}/$@ .
+	${GO} build -ldflags "-X main.gitCommit=${GIT_COMMIT}" -o ${CURDIR}/$@ .
 
 all: bin/linuxkit bin/manifest-tool

--- a/build-tools/Makefile
+++ b/build-tools/Makefile
@@ -1,21 +1,21 @@
-PATH := $(CURDIR)/bin:$(PATH)
+PATH := ${CURDIR}/bin:${PATH}
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
 BUILD_TOOLS=bin/linuxkit bin/manifest-tool
-GOC=GOPATH=$(CURDIR) go
+GOC=GOPATH=${CURDIR} go
 
 %Gopkg.lock: %Gopkg.toml
-	cd `dirname $@` ; GOPATH=$(CURDIR) $(CURDIR)/bin/dep ensure -v
+	cd `dirname $@` ; GOPATH=${CURDIR} ${CURDIR}/bin/dep ensure -v
 
 bin/linuxkit: src/linuxkit/Gopkg.lock
 	cd src/linuxkit/vendor/github.com/linuxkit/linuxkit/src/cmd/linuxkit ;\
-	$(GOC) build -ldflags "-X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.GitCommit=${COMMIT}" -o $(CURDIR)/$@ .
+	${GOC} build -ldflags "-X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.GitCommit=${COMMIT}" -o ${CURDIR}/$@ .
 
 bin/manifest-tool: src/manifest-tool/Gopkg.lock
 	cd src/manifest-tool/vendor/github.com/estesp/manifest-tool ;\
-	$(GOC) build -ldflags "-X main.gitCommit=${COMMIT}" -o $(CURDIR)/$@ .
+	${GOC} build -ldflags "-X main.gitCommit=${COMMIT}" -o ${CURDIR}/$@ .
 
 bin/dep:
-	$(GOC) get github.com/golang/dep/cmd/dep
+	${GOC} get github.com/golang/dep/cmd/dep
 
 all: bin/dep bin/linuxkit bin/manifest-tool

--- a/build-tools/Makefile
+++ b/build-tools/Makefile
@@ -4,7 +4,10 @@ COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}
 BUILD_TOOLS=bin/linuxkit bin/manifest-tool
 GOC=GOPATH=${CURDIR} go
 
-%Gopkg.lock: %Gopkg.toml
+bin/dep:
+	${GOC} get github.com/golang/dep/cmd/dep
+
+%Gopkg.lock: bin/dep %Gopkg.toml
 	cd `dirname $@` ; GOPATH=${CURDIR} ${CURDIR}/bin/dep ensure -v
 
 bin/linuxkit: src/linuxkit/Gopkg.lock
@@ -15,7 +18,4 @@ bin/manifest-tool: src/manifest-tool/Gopkg.lock
 	cd src/manifest-tool/vendor/github.com/estesp/manifest-tool ;\
 	${GOC} build -ldflags "-X main.gitCommit=${COMMIT}" -o ${CURDIR}/$@ .
 
-bin/dep:
-	${GOC} get github.com/golang/dep/cmd/dep
-
-all: bin/dep bin/linuxkit bin/manifest-tool
+all: bin/linuxkit bin/manifest-tool


### PR DESCRIPTION
Requesting moving the build-tools Makefile hierarchy into its own subdirectory.

This will allow us some flexibility in separating build vs. runtime tools, as well as potentially easing migrating it into zdk in the future if needed.
