### PR TITLE
Add /usr/sbin/watchdog to zedctr

### DIFF
--- a/parse-pkgs.sh
+++ b/parse-pkgs.sh
@@ -33,6 +33,7 @@ QREXECLIB_TAG=$(linuxkit_tag pkg/qrexec-lib)-$ARCH
 WWAN_TAG=$(linuxkit_tag pkg/wwan)-$ARCH
 WLAN_TAG=$(linuxkit_tag pkg/wlan)-$ARCH
 GPTTOOLS_TAG=$(linuxkit_tag pkg/gpt-tools)-$ARCH
+WATCHDOG_TAG=$(linuxkit_tag pkg/watchdog)-$ARCH
 
 # Plugin tags: the following tags will default to
 # 'scratch' Docker container if not available.
@@ -56,5 +57,6 @@ sed -e "s#KERNEL_TAG#"$KERNEL_TAG"#" \
     -e "s#WLAN_TAG#"$WLAN_TAG"#" \
     -e "s#GRUB_TAG#"$GRUB_TAG"#" \
     -e "s#GPTTOOLS_TAG#"$GPTTOOLS_TAG"#" \
+    -e "s#WATCHDOG_TAG#"$WATCHDOG_TAG"#" \
     -e "s#KMOD_PFRING_TAG#"$KMOD_PFRING_TAG"#" \
     $1

--- a/pkg/zedctr/Dockerfile.in
+++ b/pkg/zedctr/Dockerfile.in
@@ -3,6 +3,7 @@ FROM XENTOOLS_TAG as xen-tools
 FROM DNSMASQ_TAG as dnsmasq
 FROM TESTMSVCS_TAG as msvcs
 FROM GPTTOOLS_TAG as gpttools
+FROM WATCHDOG_TAG as watchdog
 
 FROM alpine:3.6
 RUN apk add --no-cache \
@@ -22,6 +23,7 @@ COPY --from=ztools / /
 COPY --from=gpttools / /
 COPY --from=dnsmasq /usr/sbin/dnsmasq /opt/zededa/bin/dnsmasq
 COPY --from=msvcs /vms /vms
+COPY --from=watchdog /usr/sbin /usr/sbin
 
 # And now a few local tweaks
 COPY rootfs/ /


### PR DESCRIPTION
Just copying the output of one build container to the zedctr to make it available at runtime