### PR TITLE
Initial port of zenbuild to aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,25 @@ ZARCH=$(shell uname -m)
 DOCKER_ARCH_TAG_aarch64=arm64
 DOCKER_ARCH_TAG_x86_64=amd64
 DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG_$(ZARCH))
-QEMU_OPTS_aarch64=-machine virt,gic_version=3 -machine virtualization=true -cpu cortex-a57 -machine type=virt \
-                  -drive file=./bios/OVMF.fd,format=raw,if=pflash -drive file=./bios/flash1.img,format=raw,if=pflash
-QEMU_OPTS_x86_64=--bios ./bios/OVMF.fd -cpu SandyBridge
-QEMU_OPTS_COMMON= -m 4096 -smp 4 -display none -serial mon:stdio \
+
+FALLBACK_IMG_aarch64=fallback_aarch64.img
+FALLBACK_IMG_x86_64=fallback.img
+FALLBACK_IMG=$(FALLBACK_IMG_$(ZARCH))
+
+ROOTFS_IMG_aarch64=rootfs_aarch64.img
+ROOTFS_IMG_x86_64=rootfs.img
+ROOTFS_IMG=$(ROOTFS_IMG_$(ZARCH))
+
+QEMU_OPTS_aarch64= -machine virt,gic_version=3 -machine virtualization=true -cpu cortex-a57 -machine type=virt
+# -drive file=./bios/flash0.img,format=raw,if=pflash -drive file=./bios/flash1.img,format=raw,if=pflash
+# [ -f bios/flash1.img ] || dd if=/dev/zero of=bios/flash1.img bs=1048576 count=64
+QEMU_OPTS_x86_64= -cpu SandyBridge
+QEMU_OPTS_COMMON= -m 4096 -smp 4 -serial mon:stdio -bios ./bios/OVMF.fd \
 	-net nic,vlan=0 -net user,id=eth0,vlan=0,net=192.168.1.0/24,dhcpstart=192.168.1.10,hostfwd=tcp::2222-:22 \
 	-net nic,vlan=1 -net user,id=eth1,vlan=1,net=192.168.2.0/24,dhcpstart=192.168.2.10
 QEMU_OPTS=$(QEMU_OPTS_COMMON) $(QEMU_OPTS_$(ZARCH))
+
+DOCKER_UNPACK= _() { C=`docker create $$1 fake` ; docker export $$C | tar -xf - $$2 ; docker rm $$C ; } ; _
 
 .PHONY: run pkgs build-pkgs help build-tools
 
@@ -37,11 +49,16 @@ build-pkgs: build-tools
 pkgs: build-tools build-pkgs
 	make -C pkg
 
-bios/OVMF.fd:
-	mkdir bios || :
-	[ -f bios/flash1.img ] || dd if=/dev/zero of=bios/flash1.img bs=1048576 count=64
-	C=`docker create $(shell make -s -C build-pkgs BUILD-PKGS=uefi show-tag)-$(DOCKER_ARCH_TAG) fake` ;\
-	   docker export $$C | tar -C bios -xf - OVMF* ; docker rm $$C
+bios:
+	mkdir bios
+
+bios/EFI: bios
+	cd bios ; $(DOCKER_UNPACK) $(shell make -s -C pkg PKGS=grub show-tag)-$(DOCKER_ARCH_TAG) EFI
+	cd bios/EFI/BOOT ; mv BOOTAA64GNU.EFI B ; rm BOOT* ; mv B BOOTAA64.EFI
+	(echo "set root=(hd0)" ; echo "chainloader /EFI/BOOT/BOOTAA64GNU.EFI" ; echo boot) > bios/EFI/BOOT/grub.cfg
+
+bios/OVMF.fd: bios
+	cd bios ; $(DOCKER_UNPACK) $(shell make -s -C build-pkgs BUILD-PKGS=uefi show-tag)-$(DOCKER_ARCH_TAG) OVMF.fd
 
 # run-installer
 #
@@ -54,23 +71,45 @@ run-installer:
 	qemu-system-$(ZARCH) $(QEMU_OPTS) -hda target.img -cdrom installer.iso -boot d
 
 run-fallback run: bios/OVMF.fd
-	qemu-system-$(ZARCH) $(QEMU_OPTS) -hda fallback.img
+	qemu-system-$(ZARCH) $(QEMU_OPTS) -drive file=$(FALLBACK_IMG),format=raw
 
-images/%.yml: pkgs parse-pkgs.sh images/%.yml.in FORCE
+run-rootfs: bios/OVMF.fd bios/EFI $(ROOTFS_IMG)
+	qemu-system-$(ZARCH) $(QEMU_OPTS) -drive file=$(ROOTFS_IMG),format=raw -drive file=fat:rw:./bios/,format=raw 
+
+images/%.yml: parse-pkgs.sh images/%.yml.in
 	./parse-pkgs.sh $@.in > $@
+	# the following is a horrible hack that needs to go away ASAP
+	if [ "$(ZARCH)" != `uname -m` ] ; then \
+	   sed -e 's#-amd64\s*$$##' -e 's#-arm64\s*$$##' \
+               -e '/linuxkit|zededa\/[^:]*:/s#\s*$$#-$(DOCKER_ARCH_TAG)#' -E -i.orig $@ ;\
+	   echo "WARNING: We are assembling a $(ZARCH) image on `uname -m`. Things may break." ;\
+        fi
 
-rootfs.img: images/fallback.yml
-	./makerootfs.sh images/fallback.yml squash rootfs.img
+$(ROOTFS_IMG): images/fallback.yml
+	./makerootfs.sh images/fallback.yml squash $@
 
 config.img:
 	./maketestconfig.sh config.img
 
-fallback.img: rootfs.img config.img
-	tar c rootfs.img config.img | ./makeflash.sh -C ${MEDIA_SIZE} $@
+$(FALLBACK_IMG): $(ROOTFS_IMG) config.img
+	# FIXME: the following is a workaround for GRUB on aarch64
+	if [ "$(ZARCH)" == aarch64 ] ; then \
+	  rm -f grub.tar 2>/dev/null || : ;\
+          $(DOCKER_UNPACK) $(shell make -s -C pkg PKGS=grub show-tag)-$(DOCKER_ARCH_TAG) EFI ;\
+	  mv EFI/BOOT/BOOTAA64.EFI EFI/BOOT/B ; rm -f EFI/BOOT/BOOT* ; mv EFI/BOOT/B EFI/BOOT/BOOTAA64.EFI ;\
+          (echo 'gptprio.next -d dev -u uuid' ;\
+           echo 'set root=$$dev' ;\
+           echo 'chainloader ($$dev)/EFI/BOOT/BOOTAA64GNU.EFI' ;\
+           echo 'boot' ;\
+           echo 'reboot') > EFI/BOOT/grub.cfg ;\
+          tar cf grub.tar EFI ; rm -rf EFI ;\
+          GRUB_IMG=grub.tar ;\
+        fi ;\
+	tar c $${GRUB_IMG} $(ROOTFS_IMG) config.img | ./makeflash.sh -C ${MEDIA_SIZE} $@
 
 .PHONY: pkg_installer
-pkg_installer: rootfs.img config.img
-	cp rootfs.img config.img pkg/installer
+pkg_installer: $(ROOTFS_IMG) config.img
+	cp $(ROOTFS_IMG) config.img pkg/installer
 	make -C pkg PKGS=installer LINUXKIT_OPTS="--disable-content-trust --disable-cache" forcebuild
 
 #

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -50,8 +50,41 @@ RUN cd grub ; case $(uname -m) in \
     ;; \
   esac
 
+# ARM HACK STARTS HERE -- REFACTOR ASAP
+FROM alpine:3.7 as build-gnu
+ENV GRUB_MODULES_PORT="part_gpt fat ext2 iso9660 squash4 gzio linux acpi normal cpio crypto disk boot crc64 gpt \
+search_disk_uuid verify xzio xfs video gfxterm efi_gop gptprio chain probe reboot "
+ENV GRUB_MODULES_x86_64="multiboot2 efi_uga linuxefi"
+ENV GRUB_MODULES_aarch64="xen_boot"
+WORKDIR /grub
+COPY --from=grub-build /grub-lib /grub-lib
+
+RUN apk add --no-cache dtc xz-dev linux-headers gcc automake make bison libc-dev flex autoconf bash python git
+
+RUN cd / ; git clone git://git.sv.gnu.org/grub.git ; cd grub ; git checkout 71f9e4ac44142af52c3fc1860436cf9e432bf764
+RUN ./autogen.sh ; ./configure --libdir=/grub-lib --with-platform=efi
+# --target=aarch64-linux-gnu
+RUN make ; make install
+
+COPY virt-gicv3.dts /grub
+RUN dtc -O dtb -o /grub-lib/virt-gicv3.dtb -I dts /grub/virt-gicv3.dts
+
+# create the grub core image
+RUN case $(uname -m) in \
+  x86_64) \
+    ./grub-mkimage -O x86_64-efi -d /grub-lib/grub/x86_64-efi -o /grub-lib/BOOTX64GNU.EFI -p /EFI/BOOT ${GRUB_MODULES_PORT} ${GRUB_MODULES_x86_64} part_msdos ;\
+    ;; \
+  aarch64) \
+    ./grub-mkimage -O arm64-efi -d /grub-lib/grub/arm64-efi -o /grub-lib/BOOTAA64GNU.EFI -p /EFI/BOOT ${GRUB_MODULES_PORT} ${GRUB_MODULES_aarch64} part_msdos ;\
+    ;; \
+  esac
+# ARM HACK ENDS HERE -- REFACTOR ASAP
+
+
 FROM scratch
 ENTRYPOINT []
 CMD []
 WORKDIR /EFI/BOOT
 COPY --from=grub-build /grub-lib/BOOT*.EFI ./
+COPY --from=build-gnu /grub-lib/BOOT*.EFI ./
+COPY --from=build-gnu /grub-lib/virt-gicv3.dtb ./

--- a/pkg/mkflash/make-flash
+++ b/pkg/mkflash/make-flash
@@ -4,15 +4,20 @@ set -ex
 
 IMGFILE=$1
 
-ESP_FILE=/parts/efifs.img
-IMGA_FILE=/parts/rootfs.img
-CONF_FILE=/parts/config.img
-
 #
 # Step 1: Extract partitions from stdin
 #
 mkdir -p /parts
 [ -t 0 ] || (cd /parts; bsdtar xzf -)
+
+ESP_FILE=/parts/efifs.img
+IMGA_FILE=`echo /parts/rootfs*.img | cut -f1 -d\ ` 
+CONF_FILE=/parts/config.img
+
+#
+# Step 1.1: FIXME: this is a horrible hack that needs to go away ASAP
+#
+[ -f /parts/grub.tar ] && (rm -rf /efifs/* ; tar -C /efifs -xf /parts/grub.tar)
 
 IMAGE_SIZE=$(( 300 * 1024 * 1024 ))
 

--- a/pkg/mkrootfs-ext4/make-rootfs
+++ b/pkg/mkrootfs-ext4/make-rootfs
@@ -50,6 +50,18 @@ menuentry 'LinuxKit Image on QEMU' {
 	multiboot2 /boot/xen.gz clocksource=pit console=com1
 	module2 /boot/kernel console=hvc0 clocksource=jiffies ${CMDLINE} root=PARTUUID=\$partuuid text
 }
+
+menuentry 'LinuxKit Image on QEMU/ARM64 rootfs' {
+        xen_hypervisor /boot/xen.efi options=console=dtuart noreboot dom0_mem=2048M
+        xen_module /boot/kernel console=hvc0 hmp-unsafe=true ${CMDLINE} root=/dev/vda text
+        devicetree /EFI/BOOT/virt-gicv3.dtb
+}
+
+menuentry 'LinuxKit Image on QEMU/ARM64' {
+        xen_hypervisor /boot/xen.efi options=console=dtuart noreboot dom0_mem=2048M
+        xen_module /boot/kernel console=hvc0 hmp-unsafe=true ${CMDLINE} root=/dev/vda2 text
+        devicetree /EFI/BOOT/virt-gicv3.dtb
+}
 EOF
 
   ROOTFS_BLOCKSZ=4096

--- a/pkg/mkrootfs-squash/make-rootfs
+++ b/pkg/mkrootfs-squash/make-rootfs
@@ -50,6 +50,18 @@ menuentry 'LinuxKit Image on QEMU' {
 	multiboot2 /boot/xen.gz clocksource=pit console=com1
 	module2 /boot/kernel console=hvc0 clocksource=jiffies ${CMDLINE} root=PARTUUID=\$partuuid text
 }
+
+menuentry 'LinuxKit Image on QEMU/ARM64 rootfs' {
+        xen_hypervisor /boot/xen.efi options=console=dtuart noreboot dom0_mem=2048M
+        xen_module /boot/kernel console=hvc0 hmp-unsafe=true ${CMDLINE} root=/dev/vda text
+        devicetree /EFI/BOOT/virt-gicv3.dtb
+}
+
+menuentry 'LinuxKit Image on QEMU/ARM64' {
+        xen_hypervisor /boot/xen.efi options=console=dtuart noreboot dom0_mem=2048M
+        xen_module /boot/kernel console=hvc0 hmp-unsafe=true ${CMDLINE} root=/dev/vda2 text
+        devicetree /EFI/BOOT/virt-gicv3.dtb
+}
 EOF
 
   ROOTFS_BLOCKSZ=4096


### PR DESCRIPTION
This patchset is a very early alpha version of the port. Still, make fallback.img works as expected now.

Thanks to Cherry for some of the initial work on this.