### PR TITLE
larger MEDIA_SIZE so we can do baseos-update using qemu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PATH := $(CURDIR)/build-tools/bin:$(PATH)
 
 # How large to we want the disk to be in Mb
-MEDIA_SIZE=700
+MEDIA_SIZE=8192
 
 ZARCH=$(shell uname -m)
 DOCKER_ARCH_TAG_aarch64=arm64
@@ -50,7 +50,7 @@ bios/OVMF.fd:
 # testing.
 #
 run-installer:
-	dd if=/dev/zero of=target.img count=750000 bs=1024
+	dd if=/dev/zero of=target.img seek=${MEDIA_SIZE} count=1 bs=1M
 	qemu-system-$(ZARCH) $(QEMU_OPTS) -hda target.img -cdrom installer.iso -boot d
 
 run-fallback run: bios/OVMF.fd


### PR DESCRIPTION
There are still issues with the e2e testing due to
 - qemu clock is way out of whack resulting in S3 download failing as below. Workaround is to manually set date/time in qemu before trying the update
 - the rootfs which is built has the non-qemu default of zero, which means it will not boot correctly.

Clock-related failure:
tail -f /persist/IMGA/log/downloader.log
Syncer Download Status on intermediate.cert.pem - error RequestTimeTooSkewed: The difference between the request time and the current time is too large.
    status code: 403, request id: 86F0DDE352367F68, host id: xJ6Hd2sY3jAULW2ENsudVGp6qTDHirmT/PuXrJWPCum1GrygkrONtqDXgMZR8tOd7ckFKKcYvbA=
Syncer Download Status on intermediate.cert.pem - error RequestError: send request failed
caused by: Get http://zededa-cert-repo.s3.us-west-2.amazonaws.com/intermediate.cert.pem: dial tcp: address [fe80::133:c3c7:b946:6e54]:0: no suitable address found 

