### PR TITLE
better working clock in qemu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ QEMU_OPTS_aarch64=-machine virt,gic_version=3 -machine virtualization=true -cpu 
                   -drive file=./bios/OVMF.fd,format=raw,if=pflash -drive file=./bios/flash1.img,format=raw,if=pflash
 QEMU_OPTS_x86_64=--bios ./bios/OVMF.fd -cpu SandyBridge
 QEMU_OPTS_COMMON= -m 4096 -smp 4 -display none -serial mon:stdio \
+	-rtc base=utc,clock=rt \
 	-net nic,vlan=0 -net user,id=eth0,vlan=0,net=192.168.1.0/24,dhcpstart=192.168.1.10,hostfwd=tcp::2222-:22 \
 	-net nic,vlan=1 -net user,id=eth1,vlan=1,net=192.168.2.0/24,dhcpstart=192.168.2.10
 QEMU_OPTS=$(QEMU_OPTS_COMMON) $(QEMU_OPTS_$(ZARCH))

--- a/pkg/mkimage-iso-efi/make-efi
+++ b/pkg/mkimage-iso-efi/make-efi
@@ -54,8 +54,7 @@ menuentry 'LinuxKit ISO Image' {
 }
 menuentry 'LinuxKit ISO Image on QEMU' {
 	multiboot2 /boot/xen.gz clocksource=pit console=com1
-
-	module2 /boot/kernel console=hvc0 clocksource=jiffies ${CMDLINESR} ro text
+	module2 /boot/kernel console=hvc0 clocksource=tsc clocksource_failover=xen ${CMDLINESR} ro text
 }
 EOF
 

--- a/pkg/mkrootfs-ext4/make-rootfs
+++ b/pkg/mkrootfs-ext4/make-rootfs
@@ -48,7 +48,7 @@ menuentry 'LinuxKit Image' {
 
 menuentry 'LinuxKit Image on QEMU' {
 	multiboot2 /boot/xen.gz clocksource=pit console=com1
-	module2 /boot/kernel console=hvc0 clocksource=jiffies ${CMDLINE} root=PARTUUID=\$partuuid text
+	module2 /boot/kernel console=hvc0 clocksource=tsc clocksource_failover=xen ${CMDLINE} root=PARTUUID=\$partuuid text
 }
 EOF
 

--- a/pkg/mkrootfs-squash/make-rootfs
+++ b/pkg/mkrootfs-squash/make-rootfs
@@ -48,7 +48,7 @@ menuentry 'LinuxKit Image' {
 
 menuentry 'LinuxKit Image on QEMU' {
 	multiboot2 /boot/xen.gz clocksource=pit console=com1
-	module2 /boot/kernel console=hvc0 clocksource=jiffies ${CMDLINE} root=PARTUUID=\$partuuid text
+	module2 /boot/kernel console=hvc0 clocksource=tsc clocksource_failover=xen ${CMDLINE} root=PARTUUID=\$partuuid text
 }
 EOF
 


### PR DESCRIPTION
With these tweaks the clock in qemu is sane (as long as you don't suspend the laptop). The clock can drift by seconds as opposed to minutes; those seconds ntpd can adjust for.

Should we also delete/disable the ntpd container since it does nothing?