### PR TITLE
Stop the make of build-tools if go is not found

### DIFF
--- a/build-tools/Makefile
+++ b/build-tools/Makefile
@@ -4,6 +4,10 @@ PATH := ${CURDIR}/bin:${PATH}
 GOPATH := ${CURDIR}
 GO = $(shell which go) # XXX: Provide more precise method.
 
+ifndef GO
+$(error go executable was not found)
+endif
+
 # Export some of them to subshells
 export PATH
 export GOPATH


### PR DESCRIPTION
This is a simple error check that might help some folks debugging. (like me)