### PR TITLE
Single output directory dist/ and some convenience targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+build-tools/bin/

--- a/makeiso.sh
+++ b/makeiso.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 # Usage:
 #
-#     ./makeiso.sh <image.yml> <output.iso>
+#     ./makeiso.sh <image.yml> <build-dir> <output.iso>
 #
 MKIMAGE_TAG="$(linuxkit pkg show-tag pkg/mkimage-iso-efi)"
+YMLFILE=
+case $1 in
+    /*) YMLFILE=$1 ;;
+    *) YMLFILE=$PWD/$1 ;;
+esac
 
-linuxkit build -o - $1 | docker run -i ${MKIMAGE_TAG} > $2
+(cd $2 && linuxkit build -o - $YMLFILE) | docker run -i ${MKIMAGE_TAG} > $3

--- a/makerootfs.sh
+++ b/makerootfs.sh
@@ -1,26 +1,35 @@
 #!/bin/sh
 # Usage:
 #
-#     ./makerootfs.sh <image.yml> <fs> <output.img>
+#     ./makerootfs.sh <image.yml> <build-dir> <fs> <output.img>
+#
+#     will cd to <build-dir> before running `linuxkit build`
 
+set -e
 
 usage() {
     echo "Usage:"
     echo
-    echo "$0 <image.yml> {ext4|squash} <output.img>"
+    echo "$0 <image.yml> <build-dir> {ext4|squash} <output.img>"
+    echo "	will cd to <build-dir> before running linuxkit build"
     echo
     exit 1
 }
 
-if [ $# -ne 3 ]; then
+if [ $# -ne 4 ]; then
     usage
 fi
 
-case $2 in
+case $3 in
     ext4) MKROOTFS_PKG=mkrootfs-ext4 ;;
     squash) MKROOTFS_PKG=mkrootfs-squash ;;
     *) usage
 esac
 MKROOTFS_TAG="$(linuxkit pkg show-tag pkg/${MKROOTFS_PKG})"
+YMLFILE=
+case $1 in
+    /*) YMLFILE=$1 ;;
+    *) YMLFILE=$PWD/$1 ;;
+esac
 
-linuxkit build -o - $1 | docker run -v /dev:/dev --privileged -i ${MKROOTFS_TAG} > $3
+(cd $2 && linuxkit build -o - $YMLFILE) | docker run -v /dev:/dev --privileged -i ${MKROOTFS_TAG} > $4


### PR DESCRIPTION
Some testing thus far. Concentrates all output artifacts in `dist/` and adds a `.gitignore` file, so everything is in `dist/amd64/` or `dist/arm64/`.

This leads to some nice simplification in areas of the Makefile, with more to come.

