### PR TITLE
Fix symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ $(ROOTFS_IMG): images/rootfs.yml $(DIST)
 
 $(FALLBACK_IMG).img: $(FALLBACK_IMG).$(IMG_FORMAT) $(DIST)
 	@rm -f $@ >/dev/null 2>&1 || :
-	ln -s $< $@
+	ln -s $(<F) $@
 
 $(FALLBACK_IMG).qcow2: $(FALLBACK_IMG).raw $(DIST)
 	qemu-img convert -c -f raw -O qcow2 $< $@


### PR DESCRIPTION
Two things:

1. Removes extra '|' that somehow made it into makefile (must have been my own copy-paste error).
2. Fixes `ln -s ` target to be just filename.