### PR TITLE
CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2
+jobs:
+  build:
+    machine:
+      image: circleci/classic:latest
+    steps:
+      - checkout
+      - run: 
+          name: Packages
+          command: make pkgs
+      - run:
+          name: Zenix
+          command: make zenix
+


### PR DESCRIPTION
Once this is merged in (or before), we need to enable this repo for circleCI. I am not an admin on this repo, so I cannot do it.